### PR TITLE
fixed parsing bugs POC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 /vcpkg_installed/
+/RegistryPerformanceViewer/results

--- a/RegistryPerformanceViewer/RegistryPerformanceViewer.vcxproj
+++ b/RegistryPerformanceViewer/RegistryPerformanceViewer.vcxproj
@@ -152,9 +152,11 @@
   <ItemGroup>
     <ClCompile Include="RegistryPerformanceViewer.cpp" />
     <ClCompile Include="RegistryPerformanceViewerLogic.cpp" />
+    <ClCompile Include="Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RegistryPerformanceViewerLogic.hpp" />
+    <ClInclude Include="Utils.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RegistryPerformanceViewerLib\RegistryPerformanceViewerLib.vcxproj">

--- a/RegistryPerformanceViewer/RegistryPerformanceViewer.vcxproj.filters
+++ b/RegistryPerformanceViewer/RegistryPerformanceViewer.vcxproj.filters
@@ -21,9 +21,15 @@
     <ClCompile Include="RegistryPerformanceViewerLogic.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Utils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="RegistryPerformanceViewerLogic.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/RegistryPerformanceViewer/RegistryPerformanceViewerLogic.cpp
+++ b/RegistryPerformanceViewer/RegistryPerformanceViewerLogic.cpp
@@ -8,6 +8,7 @@
 #include "../RegistryPerformanceViewerLib/CounterData.hpp"
 
 #include "csv.hpp"
+#include "Utils.hpp"
 
 using namespace performance_data;
 
@@ -25,7 +26,7 @@ void RegistryPerformanceViewerLogic::dump_all_counters(const std::filesystem::pa
     CounterNames counters;
 
     for (const std::wstring& counter_name : counters.counter_names()) {
-        dump_specific_counter(counter_name, output_directory / counter_name);
+        dump_specific_counter(counter_name, output_directory / Utils::fix_path(counter_name));
     }
 }
 
@@ -34,26 +35,30 @@ void RegistryPerformanceViewerLogic::dump_specific_counter(const std::wstring& c
     std::filesystem::create_directories(output_directory);
 
     CounterNames counters;
-   
+
     CounterData counter(counters.counter_id(counter_name));
+
     std::map<CounterName, PerfInstances> instance_map = counter.instances();
     if (instance_map.empty()) {
         return;
     }
 
     for (const auto& [counter_name, instances] : instance_map) {
-
+        
         std::ofstream output_file(output_directory / (counter_name + L".csv"));
         auto writer = csv::make_csv_writer(output_file);
         std::vector<std::string> csv_headers_row;
         csv_headers_row.push_back("Instance name");
+        if (instances.empty()) {
+            continue;
+        }
+
         for (const Counter& counter : instances[0].counters) {
             std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
             std::string name_narrow = converter.to_bytes(counter.name);
             csv_headers_row.push_back(name_narrow);
         }
         writer << csv_headers_row;
-
 
         for (const PerfInstance& instance : instances) {
 

--- a/RegistryPerformanceViewer/Utils.cpp
+++ b/RegistryPerformanceViewer/Utils.cpp
@@ -2,11 +2,10 @@
 
 std::wstring Utils::fix_path(const std::wstring& path)
 {
-    static const std::wstring invalid_chars{L'<', L'>', L':', L'"', L'/', L'\\', L'|', L'?', L'*'};
+    static const std::wstring invalid_chars{ L'<', L'>', L':', L'"', L'/', L'\\', L'|', L'?', L'*' };
     std::wstring new_path(path);
     for (wchar_t& wchar : new_path) {
-        if (invalid_chars.contains(wchar))
-        {
+        if (invalid_chars.contains(wchar)) {
             wchar = L'_';
         }
     }

--- a/RegistryPerformanceViewer/Utils.cpp
+++ b/RegistryPerformanceViewer/Utils.cpp
@@ -1,0 +1,15 @@
+#include "Utils.hpp"
+
+std::wstring Utils::fix_path(const std::wstring& path)
+{
+    static const std::wstring invalid_chars{L'<', L'>', L':', L'"', L'/', L'\\', L'|', L'?', L'*'};
+    std::wstring new_path(path);
+    for (wchar_t& wchar : new_path) {
+        if (invalid_chars.contains(wchar))
+        {
+            wchar = L'_';
+        }
+    }
+
+    return new_path;
+}

--- a/RegistryPerformanceViewer/Utils.hpp
+++ b/RegistryPerformanceViewer/Utils.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+namespace Utils
+{
+std::wstring fix_path(const std::wstring& path);
+}
+

--- a/RegistryPerformanceViewerLib/CounterData.cpp
+++ b/RegistryPerformanceViewerLib/CounterData.cpp
@@ -79,7 +79,7 @@ std::vector<Counter> CounterData::parse_counter_definitions(uint32_t& current_in
             m_counter_data.data() + current_index);
 
         Counter counter{
-            .name = counter_names.counter_name(std::to_wstring(counter_definition->CounterNameTitleIndex)),
+            .name = counter_names.counter_name(std::to_wstring(counter_definition->CounterNameTitleIndex), counter_definition->CounterType),
             .counter_type = counter_definition->CounterType,
             .counter_size = counter_definition->CounterSize,
             .counter_offset = counter_definition->CounterOffset,

--- a/RegistryPerformanceViewerLib/CounterNames.cpp
+++ b/RegistryPerformanceViewerLib/CounterNames.cpp
@@ -12,9 +12,25 @@ CounterNames::CounterNames() :
 {
 }
 
-std::wstring CounterNames::counter_name(const std::wstring& counter_id) const
+std::wstring CounterNames::counter_name(const std::wstring& counter_id, uint32_t counter_type) const
 {
-    return m_counter_names.at(counter_id);
+    switch (counter_type) {
+    case PERF_AVERAGE_BASE:
+        return L"PERF_AVERAGE_BASE";
+    case PERF_COUNTER_MULTI_BASE:
+        return L"PERF_COUNTER_MULTI_BASE";
+    case PERF_LARGE_RAW_BASE:
+        return L"PERF_LARGE_RAW_BASE";
+    case PERF_RAW_BASE:
+        return L"PERF_RAW_BASE";
+    case PERF_SAMPLE_BASE:
+        return L"PERF_SAMPLE_BASE";
+    default:
+        if (!m_counter_names.contains(counter_id)) {
+            return L"counter name not found";
+        }
+        return m_counter_names.at(counter_id);
+    }
 }
 
 std::wstring CounterNames::counter_id(const std::wstring& counter_name) const

--- a/RegistryPerformanceViewerLib/CounterNames.hpp
+++ b/RegistryPerformanceViewerLib/CounterNames.hpp
@@ -14,7 +14,7 @@ public:
     CounterNames();
     ~CounterNames() = default;
 
-    [[nodiscard]] std::wstring counter_name(const std::wstring& counter_id) const;
+    [[nodiscard]] std::wstring counter_name(const std::wstring& counter_id, uint32_t counter_type = 0) const;
     [[nodiscard]] std::wstring counter_id(const std::wstring& counter_name) const;
 
     [[nodiscard]] std::set<std::wstring> counter_ids() const;


### PR DESCRIPTION
it works now
- Replaced all nonlegal path chars with _ (for the path only)
- If the counter type is a base counter (so there is no counter name) returns the type name as the counter name (https://docs.microsoft.com/en-us/windows/win32/wmisdk/base-counter-types)
- If there is no counter name and the type is not a base type "counter name not found" is returned as the name 